### PR TITLE
Naprawa logiki generowania sekcji Szczegóły

### DIFF
--- a/src/lib-public/generators/FA3/Szczegoly.spec.ts
+++ b/src/lib-public/generators/FA3/Szczegoly.spec.ts
@@ -214,9 +214,11 @@ describe(generateSzczegoly.name, () => {
 
   describe('ceny labels', () => {
     it('should add "netto" label when P_11 exists in FaWiersz', () => {
-      vi.mocked(PDFFunctions.getTable).mockReturnValue([]);
+      vi.mocked(PDFFunctions.getTable).mockReturnValueOnce([{}]).mockReturnValueOnce([]);
 
-      vi.mocked(PDFFunctions.hasColumnsValue).mockImplementation((column: string) => column === 'P_11');
+      vi.mocked(PDFFunctions.hasColumnsValue)
+        .mockImplementationOnce((column: string) => column === 'P_11')
+        .mockReturnValueOnce(false);
 
       generateSzczegoly(mockFaVat);
 
@@ -224,22 +226,55 @@ describe(generateSzczegoly.name, () => {
     });
 
     it('should add "netto" label when P_11 exists in ZamowienieWiersz', () => {
-      vi.mocked(PDFFunctions.getTable).mockReturnValue([]);
+      vi.mocked(PDFFunctions.getTable).mockReturnValueOnce([]).mockReturnValueOnce([{}]);
 
-      vi.mocked(PDFFunctions.hasColumnsValue).mockImplementation((column: string) => column === 'P_11');
+      vi.mocked(PDFFunctions.hasColumnsValue)
+        .mockReturnValueOnce(false)
+        .mockImplementationOnce((column: string) => column === 'P_11');
 
       generateSzczegoly(mockFaVat);
 
       expect(PDFFunctions.createLabelText).toHaveBeenCalledWith('Faktura wystawiona w cenach: ', 'netto');
     });
 
-    it('should add "brutto" label when P_11 does not exist', () => {
-      vi.mocked(PDFFunctions.getTable).mockReturnValue([]);
-      vi.mocked(PDFFunctions.hasColumnsValue).mockReturnValue(false);
+    it('should add "brutto" label when P_11A exist in FaWiersz', () => {
+      vi.mocked(PDFFunctions.getTable).mockReturnValueOnce([{}]).mockReturnValueOnce([]);
+
+      vi.mocked(PDFFunctions.hasColumnsValue)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false)
+        .mockImplementationOnce((column: string) => column === 'P_11A')
+        .mockReturnValueOnce(false);
 
       generateSzczegoly(mockFaVat);
 
       expect(PDFFunctions.createLabelText).toHaveBeenCalledWith('Faktura wystawiona w cenach: ', 'brutto');
+    });
+
+    it('should add "brutto" label when P_11A exist in ZamowienieWiersz', () => {
+      vi.mocked(PDFFunctions.getTable).mockReturnValueOnce([]).mockReturnValueOnce([{}]);
+
+      vi.mocked(PDFFunctions.hasColumnsValue)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(false)
+        .mockImplementationOnce((column: string) => column === 'P_11A');
+
+      generateSzczegoly(mockFaVat);
+
+      expect(PDFFunctions.createLabelText).toHaveBeenCalledWith('Faktura wystawiona w cenach: ', 'brutto');
+    });
+
+    it('should not add "brutto" or "netto" label when there are no FaWiersz and no ZamowienieWiersz', () => {
+      vi.mocked(PDFFunctions.getTable).mockReturnValue([]);
+
+      generateSzczegoly(mockFaVat);
+
+      expect(PDFFunctions.createLabelText).not.toHaveBeenCalledWith(
+        'Faktura wystawiona w cenach: ',
+        'brutto'
+      );
+      expect(PDFFunctions.createLabelText).not.toHaveBeenCalledWith('Faktura wystawiona w cenach: ', 'netto');
     });
 
     it('should add currency code label', () => {

--- a/src/lib-public/generators/FA3/Szczegoly.ts
+++ b/src/lib-public/generators/FA3/Szczegoly.ts
@@ -32,14 +32,16 @@ export function generateSzczegoly(faVat: Fa): Content[] {
   const cenyLabel1: Content[] = [];
   const cenyLabel2: Content[] = [];
 
-  if (!(faWiersze.length > 0 || zamowieniaWiersze.length > 0)) {
+  if (faWiersze.length > 0 || zamowieniaWiersze.length > 0) {
     const Any_P_11 = hasColumnsValue('P_11', faWiersze) || hasColumnsValue('P_11', zamowieniaWiersze);
+    const Any_P_11A = hasColumnsValue('P_11A', faWiersze) || hasColumnsValue('P_11A', zamowieniaWiersze);
 
     if (Any_P_11) {
       cenyLabel1.push(createLabelText('Faktura wystawiona w cenach: ', 'netto'));
-    } else {
+    } else if (Any_P_11A) {
       cenyLabel1.push(createLabelText('Faktura wystawiona w cenach: ', 'brutto'));
     }
+  } else {
     cenyLabel2.push(createLabelText('Kod waluty: ', faVat.KodWaluty));
   }
 
@@ -164,17 +166,19 @@ function generateFakturaZaliczkowa(fakturaZaliczkowaData: ObjectKeysOfFP[] | und
     return [];
   }
   const fakturaZaliczkowa = getTable(fakturaZaliczkowaData) as unknown as FA3FakturaZaliczkowaData[];
-  const fakturaZaliczkowaMapped = fakturaZaliczkowa.map(item => {
+  const fakturaZaliczkowaMapped = fakturaZaliczkowa.map((item) => {
     const fp =
-        (
-            'NrFaZaliczkowej' in item && item.NrFaZaliczkowej
-        ) ? item.NrFaZaliczkowej : ('NrKSeFFaZaliczkowej' in item ? item.NrKSeFFaZaliczkowej : undefined );
+      'NrFaZaliczkowej' in item && item.NrFaZaliczkowej
+        ? item.NrFaZaliczkowej
+        : 'NrKSeFFaZaliczkowej' in item
+          ? item.NrKSeFFaZaliczkowej
+          : undefined;
 
-    return{
-        ...item,
-        NrFaZaliczkowej : fp ?? { _text: ''},
+    return {
+      ...item,
+      NrFaZaliczkowej: fp ?? { _text: '' },
     };
-  })
+  });
   const table: Content[] = [];
 
   const fakturaZaliczkowaHeader: HeaderDefine[] = [


### PR DESCRIPTION
## Ulepszenia logiki etykiet i pokrycia testów:

- zaktualizowano logikę w funkcji `generateSzczegoly` tak, aby etykiety "netto" lub "brutto" były dodawane tylko wtedy, gdy istnieją wiersze w `FaWiersz` lub `ZamowienieWiersz`,
- dodano sprawdzanie obecności kolumn `P_11` i `P_11A` w celu określenia, którą etykietę należy dodać
Jeśli żadne wiersze nie istnieją, dodawany jest tylko kod waluty,
- rozszerzono pokrycie testowe w `Szczegoly.spec.ts` o przypadki dla etykiet "brutto" gdy istnieje `P_11A`
- dodano testy zapewniające, że żadna etykieta "netto" lub "brutto" nie jest dodawana gdy brak odpowiednich wierszy

Fixes #72 